### PR TITLE
Add composite index to verification tokens

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -22,6 +22,10 @@ USE pets;
 -- Comentário sobre as tabelas que serão criadas automaticamente pelo Hibernate
 -- As tabelas serão criadas automaticamente com base nas entidades JPA:
 -- - users
--- - verification_tokens  
+-- - verification_tokens
 -- - pets
 -- - services
+
+-- Índice composto para acelerar a busca de tokens de verificação
+CREATE INDEX idx_verification_token_lookup
+    ON verification_tokens (id_usuario, canal, utilizado, expires_at);

--- a/src/main/java/com/juliherms/agendamento/pets/users/internal/domain/VerificationToken.java
+++ b/src/main/java/com/juliherms/agendamento/pets/users/internal/domain/VerificationToken.java
@@ -7,27 +7,31 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(name = "verification_tokens")
+@Table(name = "verification_tokens",
+        indexes = {
+                @Index(name = "idx_verification_token_lookup",
+                        columnList = "id_usuario, canal, utilizado, expires_at")
+        })
 public class VerificationToken {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "id_usuario", nullable = false)
     private Long idUsuario;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "canal", nullable = false)
     private CanalVerificacao canal;
 
-    @Column(nullable = false)
+    @Column(name = "token_hash", nullable = false)
     private String tokenHash;
 
-    @Column(nullable = false)
+    @Column(name = "expires_at", nullable = false)
     private Instant expiresAt;
 
-    @Column(nullable = false)
+    @Column(name = "utilizado", nullable = false)
     private boolean utilizado;
 
     public Long getId() {


### PR DESCRIPTION
## Summary
- add composite index on verification tokens for faster lookups
- ensure id, canal, utilized, and expiry columns have explicit names
- include matching DDL in init script to create the index

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c7e505348328b5146c43b3c4c5fd