### PR TITLE
Restrict CI workflows by branch

### DIFF
--- a/.github/workflows/tests-advanced.yml
+++ b/.github/workflows/tests-advanced.yml
@@ -2,13 +2,13 @@ name: CI - Advanced Maven Tests (Java 21)
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ "master" ]
     paths:
       - "pom.xml"
       - "src/**"
       - ".github/workflows/**"
   pull_request:
-    branches: [ "**" ]
+    branches: [ "master" ]
     paths:
       - "pom.xml"
       - "src/**"
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: unit-tests
-    if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
+    if: github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
     strategy:
       matrix:
         java: ['21']
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [unit-tests, integration-tests]
-    if: always() && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
+    if: always() && (github.ref == 'refs/heads/master' || github.event_name == 'pull_request')
     strategy:
       matrix:
         java: ['21']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,13 +2,13 @@ name: CI - Maven Tests (Java 21)
 
 on:
   push:
-    branches: [ "**" ]
+    branches-ignore: [ "master" ]
     paths:
       - "pom.xml"
       - "src/**"
       - ".github/workflows/tests.yml"
   pull_request:
-    branches: [ "**" ]
+    branches-ignore: [ "master" ]
     paths:
       - "pom.xml"
       - "src/**"


### PR DESCRIPTION
## Summary
- run standard tests workflow on all branches except master
- run advanced tests workflow only on master and adjust job conditions

## Testing
- ⚠️ `./mvnw -q test` *(failed: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_68aa81bd30788328afae7440fb147192